### PR TITLE
1.12 compatibility

### DIFF
--- a/src/main/java/me/ichun/mods/ding/common/core/Ding.java
+++ b/src/main/java/me/ichun/mods/ding/common/core/Ding.java
@@ -28,7 +28,7 @@ import java.util.Locale;
         clientSideOnly = true,
         acceptableRemoteVersions = "*",
         dependencies = "required-after:forge@[13.19.0.2141,)",
-        acceptedMinecraftVersions = "[1.11,1.12)"
+        acceptedMinecraftVersions = "[1.11,1.13)"
 )
 public class Ding
 {


### PR DESCRIPTION
Setting acceptedMinecraftVersions to "[1.11,1.13)" seems to make this mod work for 1.12.1.