### PR TITLE
refactor: Set side of ding to CLIENT for Forge and Minecraft

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -18,10 +18,10 @@ issueTrackerURL="https://github.com/iChun/Ding/issues"
     mandatory=true
     versionRange="[37,)"
     ordering="NONE"
-    side="BOTH"
+    side="CLIENT"
 [[dependencies.ding]]
     modId="minecraft"
     mandatory=true
     versionRange="[1.17,1.18)"
     ordering="NONE"
-    side="BOTH"
+    side="CLIENT"


### PR DESCRIPTION
A small change in the [[dependencies.ding]] declaration which reflects the actual side of the mod when used. This will help ServerPackCreator identify the sideness in future upates.

For reference: Griefed/ServerPackCreator#70

Please let me know if you have any issues with this.

Cheers,
Griefed