### PR TITLE
update 1.19 for forge 41.0.94+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft', it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.19-41.0.1'
+    minecraft 'net.minecraftforge:forge:1.19-41.1.0'
 
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency

--- a/src/main/java/me/ichun/mods/ding/common/Ding.java
+++ b/src/main/java/me/ichun/mods/ding/common/Ding.java
@@ -10,7 +10,7 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
-import net.minecraftforge.client.event.ScreenOpenEvent;
+import net.minecraftforge.client.event.ScreenEvent;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
@@ -146,7 +146,7 @@ public class Ding
         public static boolean playWorld;
 
         @SubscribeEvent
-        public static void onGuiOpen(ScreenOpenEvent event)
+        public static void onGuiOpen(ScreenEvent.Opening event)
         {
             if(postInit && event.getScreen() instanceof TitleScreen && !played)
             {
@@ -159,13 +159,13 @@ public class Ding
         }
 
         @SubscribeEvent
-        public static void onClientLoggedInEvent(ClientPlayerNetworkEvent.LoggedInEvent event)
+        public static void onClientLoggedInEvent(ClientPlayerNetworkEvent.LoggingIn event)
         {
             playWorld = true;
         }
 
         @SubscribeEvent
-        public static void onWorldTick(TickEvent.WorldTickEvent event)
+        public static void onWorldTick(TickEvent.LevelTickEvent event)
         {
             if(playWorld && event.phase == TickEvent.Phase.END && Minecraft.getInstance().player != null && (Minecraft.getInstance().player.tickCount > 20 || Minecraft.getInstance().isPaused()))
             {

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -16,7 +16,7 @@ issueTrackerURL="https://github.com/iChun/Ding/issues"
 [[dependencies.ding]]
     modId="forge"
     mandatory=true
-    versionRange="[41,)"
+    versionRange="[41.0.94,)"
     ordering="NONE"
     side="BOTH"
 [[dependencies.ding]]


### PR DESCRIPTION
forge 41.0.94 (and 41.0.64) renamed some events this mod uses, which made the mod crash on that and any newer forge versions ([log](https://gist.github.com/adrianmgg/685ab21fc5a86c89fe72bc639bac3e6f#file-ding-1-19-1-3-0-jar-debug-log-L192-L193)).

this pr:
- upgrades forge to 41.1.0 (mod should still be compatible down to 41.0.94)
- updates things that were renamed
- changes minimum forge version in mods.toml to 41.0.94, so earlier 1.19 forge versions will fail gracefully with a graphical "Mod requires forge 41.0.94 or above" message rather than just crashing
